### PR TITLE
Add hero background preload with spinner

### DIFF
--- a/asistentes-ia.html
+++ b/asistentes-ia.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="preload" href="background/004.webp" as="image">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -203,6 +204,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+    <script src="js/hero-preload.js"></script>
     <script src="js/global.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/theme-toggle.js"></script>

--- a/aulavirtual.html
+++ b/aulavirtual.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="preload" href="background/008.webp" as="image">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -166,6 +167,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+    <script src="js/hero-preload.js"></script>
     <script src="js/global.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/theme-toggle.js"></script>

--- a/clases-presenciales.html
+++ b/clases-presenciales.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="preload" href="background/006.webp" as="image">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -270,6 +271,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+    <script src="js/hero-preload.js"></script>
     <script src="js/global.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/theme-toggle.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
-    
+
+    <link rel="preload" href="background/000.webp" as="image">
+
     <link rel="stylesheet" href="style.css">
     <title>Rodrigo Pizarro - Inicio</title> 
 </head>
@@ -261,6 +263,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+    <script src="js/hero-preload.js"></script>
     <script src="js/global.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/theme-toggle.js"></script>

--- a/js/hero-preload.js
+++ b/js/hero-preload.js
@@ -1,0 +1,30 @@
+// Preload de la imagen del héroe con indicador de carga
+
+document.addEventListener('DOMContentLoaded', () => {
+    const hero = document.querySelector('.hero-fullscreen-bg');
+    if (!hero) return;
+
+    const style = getComputedStyle(hero);
+    const bg = style.backgroundImage || '';
+    const match = bg.match(/url\(["']?(.*?)["']?\)/);
+    const imageUrl = match ? match[1] : null;
+    if (!imageUrl) return;
+
+    hero.classList.add('preload-hidden');
+
+    const overlay = document.createElement('div');
+    overlay.className = 'hero-loading-overlay';
+    overlay.innerHTML = '<div class="hero-spinner"></div>';
+    hero.appendChild(overlay);
+
+    const img = new Image();
+    img.src = imageUrl;
+    img.onload = () => {
+        hero.classList.remove('preload-hidden');
+        overlay.remove();
+    };
+    img.onerror = () => {
+        hero.classList.remove('preload-hidden');
+        overlay.remove();
+    };
+});

--- a/masajes-terapeuticos.html
+++ b/masajes-terapeuticos.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="preload" href="background/005.webp" as="image">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -198,6 +199,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+    <script src="js/hero-preload.js"></script>
     <script src="js/global.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/theme-toggle.js"></script>

--- a/style.css
+++ b/style.css
@@ -98,6 +98,38 @@ a:hover {
 .hero-aula-bg { background-image: url('background/008.webp'); }
 .hero-tienda-bg { background-image: url('background/007.webp'); }
 
+/* Preload overlay for hero images */
+.hero-fullscreen-bg.preload-hidden {
+    opacity: 0;
+}
+
+.hero-loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 2;
+}
+
+.hero-spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid var(--color-chinese-seal-red);
+    border-radius: 50%;
+    animation: hero-spin 1s linear infinite;
+}
+
+@keyframes hero-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 .section-bg-paper { 
     background-color: var(--color-bg-section); 
 }

--- a/tienda.html
+++ b/tienda.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="preload" href="background/007.webp" as="image">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -226,6 +227,7 @@
         </div>
     </footer>
 
+    <script src="js/hero-preload.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS module to preload hero background with a spinner overlay
- preload hero images in `<head>` for faster loading
- show spinner until hero image is ready

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841a2a43e808320af75ee73ee5edff7