### PR TITLE
Add smooth hero preload transitions

### DIFF
--- a/asistentes-ia.html
+++ b/asistentes-ia.html
@@ -58,7 +58,7 @@
     </div>
 </nav>
     
-    <header id="hero-ia" class="hero-fullscreen-bg hero-ia-bg text-white h-screen flex flex-col items-center justify-center relative">
+    <header id="hero-ia" class="hero-fullscreen-bg hero-ia-bg preload-hidden text-white h-screen flex flex-col items-center justify-center relative">
         <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
             <h1 class="font-title text-5xl sm:text-6xl md:text-7xl text-gray-50 mb-6 fade-in">Asistentes de IA</h1>
             <p class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-8 fade-in font-title" style="animation-delay: 0.2s;">Inteligencia Artificial para el Aprendizaje Daoísta</p>

--- a/aulavirtual.html
+++ b/aulavirtual.html
@@ -57,7 +57,7 @@
 </nav>
     
 
-    <header id="hero-aula" class="hero-fullscreen-bg hero-aula-bg text-white h-screen flex flex-col items-center justify-center relative">
+    <header id="hero-aula" class="hero-fullscreen-bg hero-aula-bg preload-hidden text-white h-screen flex flex-col items-center justify-center relative">
         <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
             <h1 class="font-title text-5xl sm:text-6xl md:text-7xl text-gray-50 mb-6 fade-in">Aula Virtual</h1>
             <p class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-8 fade-in font-title" style="animation-delay: 0.2s;">Tu Espacio Personalizado de Aprendizaje</p>

--- a/clases-presenciales.html
+++ b/clases-presenciales.html
@@ -59,7 +59,7 @@
 </nav>
 
 
-<header id="hero-clases" class="hero-fullscreen-bg hero-clases-bg h-screen flex flex-col items-center justify-center relative">        <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
+<header id="hero-clases" class="hero-fullscreen-bg hero-clases-bg preload-hidden h-screen flex flex-col items-center justify-center relative">        <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
         <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
             <h1 class="font-title text-5xl sm:text-6xl md:text-7xl text-gray-50 mb-10 fade-in leading-snug">Clases de Qígōng y Tàijíquán</h1>
                 <h2 class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-12 fade-in font-title" style="animation-delay: 0.2s;">Presenciales y Virtuales</h2>

--- a/cursos/tecnicas-qigong.html
+++ b/cursos/tecnicas-qigong.html
@@ -57,7 +57,7 @@
     </div>
 </nav>
     
-<header id="hero-tecnicas-Qígōng" class="hero-fullscreen-bg hero-tecnicas-Qígōng-bg text-white h-[50vh] md:h-[60vh] lg:h-[450px] flex flex-col items-center justify-center relative">
+<header id="hero-tecnicas-Qígōng" class="hero-fullscreen-bg hero-tecnicas-Qígōng-bg preload-hidden text-white h-[50vh] md:h-[60vh] lg:h-[450px] flex flex-col items-center justify-center relative">
     <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
         <h1 class="font-title text-5xl sm:text-6xl md:text-7xl text-gray-50 mb-6 fade-in leading-snug md:leading-tight">Técnicas de Qígōng</h1>
         <p class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-8 fade-in font-title" style="animation-delay: 0.2s;">Profundizando en el Arte del Cultivo Energético</p>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         </div>
 </nav>
     
-<header id="bienvenida" class="hero-fullscreen-bg hero-index-bg text-white h-screen flex flex-col items-center justify-center relative">
+<header id="bienvenida" class="hero-fullscreen-bg hero-index-bg preload-hidden text-white h-screen flex flex-col items-center justify-center relative">
     <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
         <h1 class="font-title text-5xl sm:text-6xl md:text-7xl lg:text-8xl text-gray-50 mb-6 fade-in" style="animation-delay: 0.2s;">Rodrigo Pizarro</h1>
             <h2 class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-3 fade-in font-title" style="animation-delay: 0.4s;">Instructor de Qígōng Taiji</h2>

--- a/js/hero-preload.js
+++ b/js/hero-preload.js
@@ -19,12 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const img = new Image();
     img.src = imageUrl;
-    img.onload = () => {
+    const revealHero = () => {
         hero.classList.remove('preload-hidden');
-        overlay.remove();
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('transitionend', () => overlay.remove(), { once: true });
     };
-    img.onerror = () => {
-        hero.classList.remove('preload-hidden');
-        overlay.remove();
-    };
+
+    img.onload = revealHero;
+    img.onerror = revealHero;
 });

--- a/masajes-terapeuticos.html
+++ b/masajes-terapeuticos.html
@@ -59,7 +59,7 @@
 </nav>
 
     
-    <header id="hero-masajes" class="hero-fullscreen-bg hero-masajes-bg text-white h-screen flex flex-col items-center justify-center relative">
+    <header id="hero-masajes" class="hero-fullscreen-bg hero-masajes-bg preload-hidden text-white h-screen flex flex-col items-center justify-center relative">
         <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
             <h1 class="font-title text-5xl sm:text-6xl md:text-7xl text-gray-50 mb-6 fade-in">El Arte del Masaje Terapéutico</h1>
             <p class="text-xl sm:text-2xl md:text-3xl text-gray-100 mb-8 fade-in font-title" style="animation-delay: 0.2s;">Tuina y An Mo</p>

--- a/style.css
+++ b/style.css
@@ -76,10 +76,11 @@ a:hover {
 .hero-fullscreen-bg {
     position: relative;
     color: white;
-    background-color: #000000; 
+    background-color: #000000;
     background-repeat: no-repeat;
     background-position: center center;
     background-size: cover;
+    transition: opacity 0.5s ease-in-out;
 }
 .hero-fullscreen-bg::before {
     position: absolute;
@@ -114,6 +115,11 @@ a:hover {
     align-items: center;
     background-color: rgba(0, 0, 0, 0.5);
     z-index: 2;
+    transition: opacity 0.5s ease;
+}
+
+.hero-loading-overlay.fade-out {
+    opacity: 0;
 }
 
 .hero-spinner {

--- a/tienda.html
+++ b/tienda.html
@@ -56,7 +56,7 @@
         </div>
     </nav>
 
- <header id="tienda" class="hero-fullscreen-bg hero-tienda-bg text-white h-screen flex flex-col items-center justify-center relative">
+ <header id="tienda" class="hero-fullscreen-bg hero-tienda-bg preload-hidden text-white h-screen flex flex-col items-center justify-center relative">
     <div class="container mx-auto px-6 text-center py-8 md:py-12 relative z-10">
         <h1 class="font-title text-5xl sm:text-6xl md:text-7xl lg:text-8xl text-gray-50 mb-6 fade-in" style="animation-delay: 0.2s;">Tienda</h1>
             <p class="text-lg sm:text-xl text-text-secondary max-w-2xl mx-auto fade-in" style="animation-delay: 0.2s;">


### PR DESCRIPTION
## Summary
- add fade transitions to hero background and loader overlay
- wait for overlay transition to end before removing it
- preload-hide hero headers in markup for improved loading

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841c029e54883208b59fa1604059a1b