### PR TITLE
Improve SEO with metadata and sitemap

### DIFF
--- a/acerca-de-mi.html
+++ b/acerca-de-mi.html
@@ -4,12 +4,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Información sobre Rodrigo Pizarro, su trayectoria en artes internas, masajes y producción multimedial."
     <script src="https://cdn.tailwindcss.com"></script>
    
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="acerca-de-mi.html">
+    <meta property="og:title" content="Acerca de Rodrigo Pizarro">
+    <meta property="og:description" content="Información sobre Rodrigo Pizarro, su trayectoria en artes internas, masajes y producción multimedial.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="acerca-de-mi.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
     <title>Acerca de Rodrigo Pizarro</title>
 </head>
 
@@ -227,11 +242,11 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
 </body>
 </html>

--- a/asistentes-ia.html
+++ b/asistentes-ia.html
@@ -4,12 +4,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Asistentes de inteligencia artificial creados por Rodrigo Pizarro para mejorar tu práctica y productividad."
     <title>Asistentes IA - Rodrigo Pizarro</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="preload" href="background/004.webp" as="image">
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="asistentes-ia.html">
+    <meta property="og:title" content="Asistentes IA - Rodrigo Pizarro">
+    <meta property="og:description" content="Asistentes de inteligencia artificial creados por Rodrigo Pizarro para mejorar tu práctica y productividad.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="asistentes-ia.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
 </head>
 
 <body class="rice-paper-bg">
@@ -202,12 +217,12 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/hero-preload.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/hero-preload.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
 </body>
 </html>

--- a/aulavirtual.html
+++ b/aulavirtual.html
@@ -3,12 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Aula virtual con recursos y cursos en línea de Qígōng y Taiji de Rodrigo Pizarro."
     <title>Aula Virtual</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="preload" href="background/008.webp" as="image">
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="aulavirtual.html">
+    <meta property="og:title" content="Aula Virtual - Rodrigo Pizarro">
+    <meta property="og:description" content="Aula virtual con recursos y cursos en línea de Qígōng y Taiji de Rodrigo Pizarro.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="aulavirtual.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
 </head>
 <body>
  <nav id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
@@ -171,12 +186,12 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/hero-preload.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/hero-preload.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
 </body>
 </html>

--- a/clases-presenciales.html
+++ b/clases-presenciales.html
@@ -4,12 +4,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Clases presenciales de Qígōng y Tàijíquán impartidas por Rodrigo Pizarro en Buenos Aires."
     <title>Clases de Qígōng y Tàijíquán</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="preload" href="background/006.webp" as="image">
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="clases-presenciales.html">
+    <meta property="og:title" content="Clases de Qígōng y Tàijíquán - Rodrigo Pizarro">
+    <meta property="og:description" content="Clases presenciales de Qígōng y Tàijíquán impartidas por Rodrigo Pizarro en Buenos Aires.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="clases-presenciales.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
 </head>
 
 <body class="rice-paper-bg">
@@ -270,12 +285,12 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/hero-preload.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/hero-preload.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sitio personal de Rodrigo Pizarro con servicios de Qígōng, Tàijíquán y masajes terapéuticos."
     <script src="https://cdn.tailwindcss.com"></script>
    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
@@ -13,6 +14,20 @@
     <link rel="preload" href="background/000.webp" as="image">
 
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="index.html">
+    <meta property="og:title" content="Rodrigo Pizarro - Inicio">
+    <meta property="og:description" content="Sitio personal de Rodrigo Pizarro, instructor de Qígōng Taiji y realizador multimedial.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="index.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
     <title>Rodrigo Pizarro - Inicio</title> 
 </head>
 
@@ -255,13 +270,13 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/hero-preload.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
-    <script src="js/form-contact.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/hero-preload.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
+    <script src="js/form-contact.js" defer></script>
 </body>
 </html>

--- a/masajes-terapeuticos.html
+++ b/masajes-terapeuticos.html
@@ -4,12 +4,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Masajes terapéuticos Tuina y An Mo ofrecidos por Rodrigo Pizarro para tu bienestar."
     <title>Masajes Terapéuticos Tuina y An Mo - Rodrigo Pizarro</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="preload" href="background/005.webp" as="image">
     <link rel="stylesheet" href="style.css">
+    <link rel="canonical" href="masajes-terapeuticos.html">
+    <meta property="og:title" content="Masajes Terapéuticos Tuina y An Mo - Rodrigo Pizarro">
+    <meta property="og:description" content="Masajes terapéuticos Tuina y An Mo ofrecidos por Rodrigo Pizarro para tu bienestar.">
+    <meta property="og:image" content="img-mias/001.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="masajes-terapeuticos.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Rodrigo Pizarro",
+      "description": "Instructor de Qígōng Taiji y realizador multimedial",
+      "url": "index.html"
+    }</script>
 </head>
 
 <body class="rice-paper-bg">
@@ -197,12 +212,12 @@
     </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script src="js/hero-preload.js"></script>
-    <script src="js/global.js"></script>
-    <script src="js/navigation.js"></script>
-    <script src="js/theme-toggle.js"></script>
-    <script src="js/animations.js"></script>
-    <script src="js/glightbox-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
+    <script src="js/hero-preload.js" defer></script>
+    <script src="js/global.js" defer></script>
+    <script src="js/navigation.js" defer></script>
+    <script src="js/theme-toggle.js" defer></script>
+    <script src="js/animations.js" defer></script>
+    <script src="js/glightbox-init.js" defer></script>
 </body>
 </html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>index.html</loc></url>
+  <url><loc>acerca-de-mi.html</loc></url>
+  <url><loc>clases-presenciales.html</loc></url>
+  <url><loc>masajes-terapeuticos.html</loc></url>
+  <url><loc>asistentes-ia.html</loc></url>
+  <url><loc>aulavirtual.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add meta descriptions and Open Graph tags
- include JSON-LD structured data
- defer non-critical scripts
- add `robots.txt` and `sitemap.xml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d3628ffc83209b068bd5a9ac15de