### PR TITLE
Fix duplicate GLightbox script tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -95,6 +95,5 @@
     <script src="js/navigation.js" defer></script>
     <script src="js/theme-toggle.js" defer></script>
     <script src="js/animations.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
 </body>
 </html>

--- a/aulavirtual.html
+++ b/aulavirtual.html
@@ -193,6 +193,5 @@
     <script src="js/navigation.js" defer></script>
     <script src="js/theme-toggle.js" defer></script>
     <script src="js/animations.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicate GLightbox script tags from `aulavirtual.html` and `404.html`
- verify GLightbox is included only once on other pages

## Testing
- `grep -n "glightbox.min.js" *.html`

------
https://chatgpt.com/codex/tasks/task_e_6849cfe9a5b08320b4ff40d14c5e0acb