### PR TITLE
Fix navigation URLs in HTML pages

### DIFF
--- a/clases/clases-particulares.html
+++ b/clases/clases-particulares.html
@@ -32,21 +32,21 @@
     <a href="#main-content" class="skip-link">Saltar al contenido</a>
     <nav aria-label="Navegación principal" id="mainNav" class="nav-opaque fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-          <a href="index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+          <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
           
           <div class="flex items-center">
             <!-- Menú Desktop -->
             <ul id="mainNavMenu" class="hidden md:flex items-center space-x-4" role="menubar">
-              <li><a href="index.html#bienvenida">Inicio</a></li>
-              <li><a href="acerca-de-mi.html">Sobre Mí</a></li>
+              <li><a href="/index.html#bienvenida">Inicio</a></li>
+              <li><a href="/acerca-de-mi.html">Sobre Mí</a></li>
               
               <!-- Clases -->
               <li class="nav-item-has-children">
                 <a>Clases</a>
                 <ul class="nav-submenu">
-                  <li><a href="clases-presenciales.html">Presenciales</a></li>
-                  <li><a href="clases-virtuales.html">Virtuales</a></li>
-                  <li><a href="clases-particulares.html">Particulares</a></li>
+                  <li><a href="/clases/clases-presenciales.html">Presenciales</a></li>
+                  <li><a href="/clases/clases-virtuales.html">Virtuales</a></li>
+                  <li><a href="/clases/clases-particulares.html">Particulares</a></li>
                 </ul>
               </li>
       
@@ -54,9 +54,9 @@
               <li class="nav-item-has-children">
                 <a>Qìgōng</a>
                 <ul class="nav-submenu">
-                  <li><a href="qigong.html">Qué es el Qìgōng</a></li>
-                  <li><a href="wudang-qigong.html">Wudang Qìgōng</a></li>
-                  <li><a href="qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
+                  <li><a href="/clases/qigong.html">Qué es el Qìgōng</a></li>
+                  <li><a href="/clases/qigong/wudangqigong.html">Wudang Qìgōng</a></li>
+                  <li><a href="/clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
                 </ul>
               </li>
       
@@ -64,7 +64,7 @@
               <li class="nav-item-has-children">
                 <a>Tàijí</a>
                 <ul class="nav-submenu">
-                  <li><a href="taiji.html">Qué es el Tàijí</a></li>
+                  <li><a href="/clases/taiji.html">Qué es el Tàijí</a></li>
                   <li><a href="/clases/taiji.html#taijiquan-sistemas">Tàijíquán</a></li>
 
                 </ul>
@@ -74,12 +74,12 @@
               <li class="nav-item-has-children">
                 <a>Servicios</a>
                 <ul class="nav-submenu">
-                  <li><a href="asistentes-ia.html">Asistentes IA</a></li>
-                  <li><a href="aulavirtual.html">Aula Virtual</a></li>
+                  <li><a href="/asistentes-ia.html">Asistentes IA</a></li>
+                  <li><a href="/aulavirtual.html">Aula Virtual</a></li>
                 </ul>
               </li>
       
-              <li><a href="index.html#contacto">Contacto</a></li>
+              <li><a href="/index.html#contacto">Contacto</a></li>
             </ul>
       
             <!-- Icono WhatsApp -->
@@ -107,15 +107,15 @@
     
       <!-- Menú Mobile -->
       <div id="mobile-menu" class="hidden absolute right-0 mt-2 w-64 md:hidden shadow-lg rounded-lg bg-white text-right">
-        <a href="../../index.html#bienvenida" class="block px-4 py-2">Inicio</a>
-        <a href="../../acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
+        <a href="/index.html#bienvenida" class="block px-4 py-2">Inicio</a>
+        <a href="/acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
     
         <!-- Clases -->
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Clases</button>
           <div class="mobile-acc-panel">
-            <a href="../clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
-            <a href="../clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
+            <a href="/clases/clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
+            <a href="/clases/clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
           </div>
         </div>
     
@@ -123,9 +123,9 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Qìgōng</button>
           <div class="mobile-acc-panel">
-            <a href="../qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
-            <a href="../wudang-qigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
-            <a href="../qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
+            <a href="/clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
+            <a href="/clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
+            <a href="/clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
           </div>
         </div>
     
@@ -133,7 +133,7 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Tàijí</button>
           <div class="mobile-acc-panel">
-            <a href="../taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
+            <a href="/clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
             <a href="/clases/taiji.html#taijiquan-sistemas" class="block px-4 py-2">Tàijíquán</a>
             <a href="/clases/taiji.html#TaijiJian-detalle" class="block px-4 py-2">Tàijíjiàn</a>
             <a  class="block px-4 py-2">Tàijíshàn</a>
@@ -145,13 +145,13 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Servicios</button>
           <div class="mobile-acc-panel">
-            <a href="../asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
-            <a href="../aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
+            <a href="/asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
           </div>
         </div>
     
         <!-- Contacto -->
-        <a href="../../index.html#contacto" class="block px-4 py-2">Contacto</a>
+        <a href="/index.html#contacto" class="block px-4 py-2">Contacto</a>
       </div>
     </div>    
 </nav>

--- a/clases/clases-presenciales.html
+++ b/clases/clases-presenciales.html
@@ -44,9 +44,9 @@
               <li class="nav-item-has-children">
                 <a>Clases</a>
                 <ul class="nav-submenu">
-                  <li><a href="clases-presenciales.html">Presenciales</a></li>
-                  <li><a href="clases-virtuales.html">Virtuales</a></li>
-                  <li><a href="clases-particulares.html">Particulares</a></li>
+                  <li><a href="/clases/clases-presenciales.html">Presenciales</a></li>
+                  <li><a href="/clases/clases-virtuales.html">Virtuales</a></li>
+                  <li><a href="/clases/clases-particulares.html">Particulares</a></li>
                 </ul>
               </li>
       

--- a/clases/qigong.html
+++ b/clases/qigong.html
@@ -34,21 +34,21 @@
     <!-- Barra de navegación reutilizada -->
     <nav aria-label="Navegación principal" id="mainNav" class="nav-opaque fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-          <a href="index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+          <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
           
           <div class="flex items-center">
             <!-- Menú Desktop -->
             <ul id="mainNavMenu" class="hidden md:flex items-center space-x-4" role="menubar">
-              <li><a href="../index.html#bienvenida">Inicio</a></li>
-              <li><a href="../acerca-de-mi.html">Sobre Mí</a></li>
+              <li><a href="/index.html#bienvenida">Inicio</a></li>
+              <li><a href="/acerca-de-mi.html">Sobre Mí</a></li>
               
               <!-- Clases -->
               <li class="nav-item-has-children">
                 <a>Clases</a>
                 <ul class="nav-submenu">
-                  <li><a href="../clases/clases-presenciales.html">Presenciales</a></li>
-                  <li><a href="../clases/clases-virtuales.html">Virtuales</a></li>
-                  <li><a href="../clases/clases-particulares.html">Particulares</a></li>
+                  <li><a href="/clases/clases-presenciales.html">Presenciales</a></li>
+                  <li><a href="/clases/clases-virtuales.html">Virtuales</a></li>
+                  <li><a href="/clases/clases-particulares.html">Particulares</a></li>
 
                 </ul>
               </li>
@@ -57,9 +57,9 @@
               <li class="nav-item-has-children">
                 <a>Qìgōng</a>
                 <ul class="nav-submenu">
-                  <li><a href="../clases/qigong.html">Qué es el Qìgōng</a></li>
-                  <li><a href="../clases/qigong/wudangqigong.html">Wudang Qìgōng</a></li>
-                  <li><a href="../clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
+                  <li><a href="/clases/qigong.html">Qué es el Qìgōng</a></li>
+                  <li><a href="/clases/qigong/wudangqigong.html">Wudang Qìgōng</a></li>
+                  <li><a href="/clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
                 </ul>
               </li>
       
@@ -67,7 +67,7 @@
               <li class="nav-item-has-children">
                 <a>Tàijí</a>
                 <ul class="nav-submenu">
-                  <li><a href="taiji.html">Qué es el Tàijí</a></li>
+                  <li><a href="/clases/taiji.html">Qué es el Tàijí</a></li>
                   <li><a href="/clases/taiji.html#taijiquan-sistemas">Tàijíquán</a></li>
 
                 </ul>
@@ -77,12 +77,12 @@
               <li class="nav-item-has-children">
                 <a>Servicios</a>
                 <ul class="nav-submenu">
-                  <li><a href="../asistentes-ia.html">Asistentes IA</a></li>
-                  <li><a href="../aulavirtual.html">Aula Virtual</a></li>
+                  <li><a href="/asistentes-ia.html">Asistentes IA</a></li>
+                  <li><a href="/aulavirtual.html">Aula Virtual</a></li>
                 </ul>
               </li>
       
-              <li><a href="../index.html#contacto">Contacto</a></li>
+              <li><a href="/index.html#contacto">Contacto</a></li>
             </ul>
       
             <!-- Icono WhatsApp -->
@@ -110,15 +110,15 @@
     
       <!-- Menú Mobile -->
       <div id="mobile-menu" class="hidden absolute right-0 mt-2 w-64 md:hidden shadow-lg rounded-lg bg-white text-right">
-        <a href="../../index.html#bienvenida" class="block px-4 py-2">Inicio</a>
-        <a href="../../acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
+        <a href="/index.html#bienvenida" class="block px-4 py-2">Inicio</a>
+        <a href="/acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
     
         <!-- Clases -->
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Clases</button>
           <div class="mobile-acc-panel">
-            <a href="../clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
-            <a href="../clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
+            <a href="/clases/clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
+            <a href="/clases/clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
           </div>
         </div>
     
@@ -126,10 +126,10 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Qìgōng</button>
           <div class="mobile-acc-panel">
-            <a href="../qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
-            <a href="../wudang-qigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
-            <a href="mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
-            <a href="../yi-jin-jing.html" class="block px-4 py-2">Yì Jīn Jīng</a>
+            <a href="/clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
+            <a href="/clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
+            <a href="/clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
+            <a href="/clases/qigong/yijinjing.html" class="block px-4 py-2">Yì Jīn Jīng</a>
           </div>
         </div>
     
@@ -137,7 +137,7 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Tàijí</button>
           <div class="mobile-acc-panel">
-            <a href="../taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
+            <a href="/clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
             <a href="/clases/taiji.html#taijiquan-sistemas" class="block px-4 py-2">Tàijíquán</a>
             <a href="/clases/taiji.html#TaijiJian-detalle" class="block px-4 py-2">Tàijíjiàn</a>
             <a  class="block px-4 py-2">Tàijíshàn</a>
@@ -149,13 +149,13 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Servicios</button>
           <div class="mobile-acc-panel">
-            <a href="../asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
-            <a href="../aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
+            <a href="/asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
           </div>
         </div>
     
         <!-- Contacto -->
-        <a href="../../index.html#contacto" class="block px-4 py-2">Contacto</a>
+        <a href="/index.html#contacto" class="block px-4 py-2">Contacto</a>
       </div>
     </div>    
 </nav>

--- a/clases/qigong/mawangduidaoyinshu.html
+++ b/clases/qigong/mawangduidaoyinshu.html
@@ -30,21 +30,21 @@
   <a href="#main-content" class="skip-link">Saltar al contenido</a>
   <nav aria-label="Navegación principal" id="mainNav" class="nav-opaque fixed w-full z-50 top-0 transition-all duration-300 ease-out">
       <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-        <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+        <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
         
         <div class="flex items-center">
           <!-- Menú Desktop -->
           <ul id="mainNavMenu" class="hidden md:flex items-center space-x-4" role="menubar">
-            <li><a href="index.html#bienvenida">Inicio</a></li>
-            <li><a href="../../acerca-de-mi.html">Sobre Mí</a></li>
+            <li><a href="/index.html#bienvenida">Inicio</a></li>
+            <li><a href="/acerca-de-mi.html">Sobre Mí</a></li>
             
             <!-- Clases -->
             <li class="nav-item-has-children">
               <a>Clases</a>
               <ul class="nav-submenu">
-                <li><a href="../../clases/clases-presenciales.html">Presenciales</a></li>
-                <li><a href="../../clases/clases-virtuales.html">Virtuales</a></li>
-                <li><a href="../../clases/clases-particulares.html">Particulares</a></li>
+                <li><a href="/clases/clases-presenciales.html">Presenciales</a></li>
+                <li><a href="/clases/clases-virtuales.html">Virtuales</a></li>
+                <li><a href="/clases/clases-particulares.html">Particulares</a></li>
               </ul>
             </li>
     
@@ -52,9 +52,9 @@
             <li class="nav-item-has-children">
               <a>Qìgōng</a>
               <ul class="nav-submenu">
-                <li><a href="../../qigong.html">Qué es el Qìgōng</a></li>
-                <li><a href="../qigong/wudangqigong.html">Wǔdāng Qìgōng</a></li>
-                <li><a href="../qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
+                <li><a href="/clases/qigong.html">Qué es el Qìgōng</a></li>
+                <li><a href="/clases/qigong/wudangqigong.html">Wǔdāng Qìgōng</a></li>
+                <li><a href="/clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
               </ul>
             </li>
     
@@ -62,7 +62,7 @@
             <li class="nav-item-has-children">
               <a>Tàijí</a>
               <ul class="nav-submenu">
-                <li><a href="../../taiji.html">Qué es el Tàijí</a></li>
+                <li><a href="/clases/taiji.html">Qué es el Tàijí</a></li>
                 <li><a href="/clases/taiji.html#taijiquan-sistemas">Tàijíquán</a></li>
               </ul>
             </li>
@@ -71,12 +71,12 @@
             <li class="nav-item-has-children">
               <a>Servicios</a>
               <ul class="nav-submenu">
-                <li><a href="../../asistentes-ia.html">Asistentes IA</a></li>
-                <li><a href="../../aulavirtual.html">Aula Virtual</a></li>
+                <li><a href="/asistentes-ia.html">Asistentes IA</a></li>
+                <li><a href="/aulavirtual.html">Aula Virtual</a></li>
               </ul>
             </li>
     
-            <li><a href="../../index.html#contacto">Contacto</a></li>
+            <li><a href="/index.html#contacto">Contacto</a></li>
           </ul>
     
           <!-- Icono WhatsApp -->
@@ -104,15 +104,15 @@
   
     <!-- Menú Mobile -->
     <div id="mobile-menu" class="hidden absolute right-0 mt-2 w-64 md:hidden shadow-lg rounded-lg bg-white text-right">
-      <a href="../../index.html#bienvenida" class="block px-4 py-2">Inicio</a>
-      <a href="../../acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
+      <a href="/index.html#bienvenida" class="block px-4 py-2">Inicio</a>
+      <a href="/acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
   
       <!-- Clases -->
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Clases</button>
         <div class="mobile-acc-panel">
-          <a href="../clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
-          <a href="../clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
+          <a href="/clases/clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
+          <a href="/clases/clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
         </div>
       </div>
   
@@ -120,9 +120,9 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Qìgōng</button>
         <div class="mobile-acc-panel">
-          <a href="../clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
-          <a href="../clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
-          <a href="../clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
+          <a href="/clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
+          <a href="/clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
+          <a href="/clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
         </div>
       </div>
   
@@ -130,7 +130,7 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Tàijí</button>
         <div class="mobile-acc-panel">
-          <a href="../clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
+          <a href="/clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
           <a href="/clases/taiji.html#taijiquan-sistemas" class="block px-4 py-2">Tàijíquán</a>
         </div>
       </div>
@@ -139,13 +139,13 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Servicios</button>
         <div class="mobile-acc-panel">
-          <a href="../asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
-          <a href="../aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
+          <a href="/asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
+          <a href="/aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
         </div>
       </div>
   
       <!-- Contacto -->
-      <a href="../../index.html#contacto" class="block px-4 py-2">Contacto</a>
+      <a href="/index.html#contacto" class="block px-4 py-2">Contacto</a>
     </div>
   </div>    
 </nav>

--- a/clases/qigong/wudangqigong.html
+++ b/clases/qigong/wudangqigong.html
@@ -30,21 +30,21 @@
   <a href="#main-content" class="skip-link">Saltar al contenido</a>
   <nav aria-label="Navegación principal" id="mainNav" class="nav-opaque fixed w-full z-50 top-0 transition-all duration-300 ease-out">
       <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-        <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+        <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
         
         <div class="flex items-center">
           <!-- Menú Desktop -->
           <ul id="mainNavMenu" class="hidden md:flex items-center space-x-4" role="menubar">
-            <li><a href="../../index.html#bienvenida">Inicio</a></li>
-            <li><a href="../../acerca-de-mi.html">Sobre Mí</a></li>
+            <li><a href="/index.html#bienvenida">Inicio</a></li>
+            <li><a href="/acerca-de-mi.html">Sobre Mí</a></li>
             
             <!-- Clases -->
             <li class="nav-item-has-children">
               <a>Clases</a>
               <ul class="nav-submenu">
-                <li><a href="../../clases/clases-presenciales.html">Presenciales</a></li>
-                <li><a href="../../clases/clases-virtuales.html">Virtuales</a></li>
-                <li><a href="../../clases/clases-particulares.html">Particulares</a></li>
+                <li><a href="/clases/clases-presenciales.html">Presenciales</a></li>
+                <li><a href="/clases/clases-virtuales.html">Virtuales</a></li>
+                <li><a href="/clases/clases-particulares.html">Particulares</a></li>
               </ul>
             </li>
     
@@ -52,9 +52,9 @@
             <li class="nav-item-has-children">
               <a>Qìgōng</a>
               <ul class="nav-submenu">
-                <li><a href="../../qigong.html">Qué es el Qìgōng</a></li>
-                <li><a href="../qigong/wudangqigong.html">Wǔdāng Qìgōng</a></li>
-                <li><a href="../qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
+                <li><a href="/clases/qigong.html">Qué es el Qìgōng</a></li>
+                <li><a href="/clases/qigong/wudangqigong.html">Wǔdāng Qìgōng</a></li>
+                <li><a href="/clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
               </ul>
             </li>
     
@@ -62,7 +62,7 @@
             <li class="nav-item-has-children">
               <a>Tàijí</a>
               <ul class="nav-submenu">
-                <li><a href="../../taiji.html">Qué es el Tàijí</a></li>
+                <li><a href="/clases/taiji.html">Qué es el Tàijí</a></li>
                 <li><a href="/clases/taiji.html#taijiquan-sistemas">Tàijíquán</a></li>
                 <li><a href="/clases/taiji.html#TaijiJian-detalle">Tàijíjiàn</a></li>
                 <li><a >Tàijíshàn</a></li>
@@ -74,12 +74,12 @@
             <li class="nav-item-has-children">
               <a>Servicios</a>
               <ul class="nav-submenu">
-                <li><a href="../../asistentes-ia.html">Asistentes IA</a></li>
-                <li><a href="../../aulavirtual.html">Aula Virtual</a></li>
+                <li><a href="/asistentes-ia.html">Asistentes IA</a></li>
+                <li><a href="/aulavirtual.html">Aula Virtual</a></li>
               </ul>
             </li>
     
-            <li><a href="../../index.html#contacto">Contacto</a></li>
+            <li><a href="/index.html#contacto">Contacto</a></li>
           </ul>
     
           <!-- Icono WhatsApp -->
@@ -107,15 +107,15 @@
   
     <!-- Menú Mobile -->
     <div id="mobile-menu" class="hidden absolute right-0 mt-2 w-64 md:hidden shadow-lg rounded-lg bg-white text-right">
-      <a href="../../index.html#bienvenida" class="block px-4 py-2">Inicio</a>
-      <a href="../../acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
+      <a href="/index.html#bienvenida" class="block px-4 py-2">Inicio</a>
+      <a href="/acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
   
       <!-- Clases -->
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Clases</button>
         <div class="mobile-acc-panel">
-          <a href="../clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
-          <a href="../clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
+          <a href="/clases/clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
+          <a href="/clases/clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
         </div>
       </div>
   
@@ -123,10 +123,10 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Qìgōng</button>
         <div class="mobile-acc-panel">
-          <a href="../qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
-          <a href="../wudang-qigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
-          <a href="../qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
-          <a href="../qigong/yijinjing.html" class="block px-4 py-2">Yì Jīn Jīng</a>
+          <a href="/clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
+          <a href="/clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
+          <a href="/clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
+          <a href="/clases/qigong/yijinjing.html" class="block px-4 py-2">Yì Jīn Jīng</a>
         </div>
       </div>
   
@@ -134,7 +134,7 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Tàijí</button>
         <div class="mobile-acc-panel">
-          <a href="../taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
+          <a href="/clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
           <a href="/clases/taiji.html#taijiquan-sistemas" class="block px-4 py-2">Tàijíquán</a>
           <a href="/clases/taiji.html#TaijiJian-detalle" class="block px-4 py-2">Tàijíjiàn</a>
           <a  class="block px-4 py-2">Tàijíshàn</a>
@@ -146,13 +146,13 @@
       <div class="mobile-accordion">
         <button class="mobile-acc-btn block px-4 py-2 w-full">Servicios</button>
         <div class="mobile-acc-panel">
-          <a href="../asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
-          <a href="../aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
+          <a href="/asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
+          <a href="/aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
         </div>
       </div>
   
       <!-- Contacto -->
-      <a href="../../index.html#contacto" class="block px-4 py-2">Contacto</a>
+      <a href="/index.html#contacto" class="block px-4 py-2">Contacto</a>
     </div>
   </div>    
 </nav>

--- a/clases/qigong/yijinjing.html
+++ b/clases/qigong/yijinjing.html
@@ -33,15 +33,15 @@
     <!-- Navegación principal reutilizada de otras páginas -->
     <nav aria-label="Navegación principal" id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-            <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+            <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
             <div class="flex items-center">
                 <div id="mainNavMenu" class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                    <a href="../../index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
-                    <a href="../../acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
-                    <a href="../../clases.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
-                    <a href="../../asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
-                    <a href="../../aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
-                    <a href="../../index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
+                    <a href="/index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
+                    <a href="/acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
+                    <a href="/clases/clases-presenciales.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
+                    <a href="/asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
+                    <a href="/aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
+                    <a href="/index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
                 </div>
                 <a href="https://api.whatsapp.com/send/?phone=5491138733447&text=Buenas%2C%20tengo%20inter%C3%A9s%20en%20tus%20servicios%20y%20me%20contacto%20por%20&type=phone_number&app_absent=0" target="_blank" rel="noopener noreferrer" title="Contactar por WhatsApp" class="p-2 focus:outline-none text-lg rounded-none" id="whatsapp-nav-icon">
                     <i aria-hidden="true" class="fab fa-whatsapp"></i>
@@ -61,12 +61,12 @@
         </div>
         <!-- Menú móvil -->
         <div id="mobile-menu" class="md:hidden hidden shadow-lg py-2 border-t">
-            <a href="../../index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
-            <a href="../../acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
-            <a href="../../clases.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases</a>
-            <a href="../../asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
-            <a href="../../aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
-            <a href="../../index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
+            <a href="/index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
+            <a href="/acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
+            <a href="/clases/clases-presenciales.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases</a>
+            <a href="/asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
+            <a href="/index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
         </div>
     </nav>
     <!-- Cabecera tipo héroe -->

--- a/clases/qigong/yijinjing_v2.html
+++ b/clases/qigong/yijinjing_v2.html
@@ -33,15 +33,15 @@
     <!-- Navegación principal reutilizada de otras páginas -->
     <nav aria-label="Navegación principal" id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-            <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+            <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
             <div class="flex items-center">
                 <div id="mainNavMenu" class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                    <a href="../../index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
-                    <a href="../../acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
-                    <a href="../../clases.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
-                    <a href="../../asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
-                    <a href="../../aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
-                    <a href="../../index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
+                    <a href="/index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
+                    <a href="/acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
+                    <a href="/clases/clases-presenciales.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
+                    <a href="/asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
+                    <a href="/aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
+                    <a href="/index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
                 </div>
                 <a href="https://api.whatsapp.com/send/?phone=5491138733447&text=Buenas%2C%20tengo%20inter%C3%A9s%20en%20tus%20servicios%20y%20me%20contacto%20por%20&type=phone_number&app_absent=0" target="_blank" rel="noopener noreferrer" title="Contactar por WhatsApp" class="p-2 focus:outline-none text-lg rounded-none" id="whatsapp-nav-icon">
                     <i aria-hidden="true" class="fab fa-whatsapp"></i>
@@ -61,12 +61,12 @@
         </div>
         <!-- Menú móvil -->
         <div id="mobile-menu" class="md:hidden hidden shadow-lg py-2 border-t">
-            <a href="../../index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
-            <a href="../../acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
-            <a href="../../clases.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases</a>
-            <a href="../../asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
-            <a href="../../aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
-            <a href="../../index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
+            <a href="/index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
+            <a href="/acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
+            <a href="/clases/clases-presenciales.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases</a>
+            <a href="/asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
+            <a href="/index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
         </div>
     </nav>
     <!-- Contenido principal -->

--- a/clases/taiji.html
+++ b/clases/taiji.html
@@ -35,16 +35,16 @@
     <!-- Barra de navegación reutilizada -->
     <nav aria-label="Navegacion principal" id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-            <a href="index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+            <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
             <div class="flex items-center">
                 <div id="mainNavMenu" class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                    <a href="index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
-                    <a href="acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
+                    <a href="/index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
+                    <a href="/acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
                     <!-- Esta entrada apunta a la página de Tai Chi -->
-                    <a href="taijichuan.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
-                    <a href="asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
-                    <a href="aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
-                    <a href="index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
+                    <a href="/clases/taiji/taijiquan-oficial-updated.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
+                    <a href="/asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
+                    <a href="/aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
+                    <a href="/index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
                 </div>
                 <a href="https://api.whatsapp.com/send/?phone=5491138733447&text=Buenas%2C%20tengo%20inter%C3%A9s%20en%20tus%20servicios%20y%20me%20contacto%20por%20&type=phone_number&app_absent=0" target="_blank" rel="noopener noreferrer" title="Contactar por WhatsApp" class="p-2 focus:outline-none text-lg rounded-none" id="whatsapp-nav-icon">
                     <i aria-hidden="true" class="fab fa-whatsapp"></i>
@@ -63,12 +63,12 @@
             </div>
         </div>
         <div id="mobile-menu" class="md:hidden hidden shadow-lg py-2 border-t">
-            <a href="index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
-            <a href="acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
-            <a href="taijichuan.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Tàijíquán</a>
-            <a href="asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
-            <a href="aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
-            <a href="index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
+                <a href="/index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
+                <a href="/acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
+                <a href="/clases/taiji/taijiquan-oficial-updated.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Tàijíquán</a>
+                <a href="/asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
+                <a href="/aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
+                <a href="/index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
         </div>
     </nav>
 

--- a/clases/taiji/taijiquan-oficial-updated.html
+++ b/clases/taiji/taijiquan-oficial-updated.html
@@ -18,16 +18,16 @@
     <!-- Navegación principal -->
     <nav aria-label="Navegacion principal" id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
         <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-            <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+            <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
 
             <div class="flex items-center">
                 <div id="mainNavMenu" class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                    <a href="../../index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
-                    <a href="../../acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
-                    <a href="../../clases.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
-                    <a href="../../asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
-                    <a href="../../aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
-                    <a href="../../index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
+                    <a href="/index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
+                    <a href="/acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
+                    <a href="/clases/clases-presenciales.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
+                    <a href="/asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
+                    <a href="/aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
+                    <a href="/index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
                 </div>
 
                 <a href="https://api.whatsapp.com/send/?phone=5491138733447&text=Buenas%2C%20tengo%20inter%C3%A9s%20en%20tus%20servicios%20y%20me%20contacto%20por%20&type=phone_number&app_absent=0" target="_blank" rel="noopener noreferrer" title="Contactar por WhatsApp" class="p-2 focus:outline-none text-lg rounded-none" id="whatsapp-nav-icon">
@@ -49,12 +49,12 @@
         </div>
 
         <div id="mobile-menu" class="md:hidden hidden shadow-lg py-2 border-t">
-            <a href="../../index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
-            <a href="../../acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
-            <a href="../../clases.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Qígōng Tàijíquán</a>
-            <a href="../../asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
-            <a href="../../aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
-            <a href="../../index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
+            <a href="/index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
+            <a href="/acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
+            <a href="/clases/clases-presenciales.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Qígōng Tàijíquán</a>
+            <a href="/asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
+            <a href="/index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
         </div>
     </nav>
 

--- a/clases/taiji/yang-moderno.html
+++ b/clases/taiji/yang-moderno.html
@@ -30,16 +30,16 @@
     <a href="#main-content" class="skip-link">Saltar al contenido</a>
 <nav aria-label="Navegacion principal" id="mainNav" class="nav-transparent fixed w-full z-50 top-0 transition-all duration-300 ease-out">
     <div class="container mx-auto px-4 sm:px-6 py-3 flex justify-between items-center">
-        <a href="../../index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
+        <a href="/index.html" id="mainNavLogo" class="font-title text-xl md:text-2xl lg:text-3xl">Rodrigo Pizarro</a>
 
         <div class="flex items-center">
             <div id="mainNavMenu" class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                <a href="../../index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
-                <a href="../../acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
-                <a href="../../clases.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
-                <a href="../../asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
-                <a href="../../aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
-                <a href="../../index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
+                <a href="/index.html#bienvenida" class="transition duration-300 text-sm lg:text-base">Inicio</a>
+                <a href="/acerca-de-mi.html" class="transition duration-300 text-sm lg:text-base">Sobre Mí</a>
+                <a href="/clases/clases-presenciales.html" class="transition duration-300 text-sm lg:text-base">Clases</a>
+                <a href="/asistentes-ia.html" class="transition duration-300 text-sm lg:text-base">Asistentes IA</a>
+                <a href="/aulavirtual.html" class="transition duration-300 text-sm lg:text-base">Aula Virtual</a>
+                <a href="/index.html#contacto" class="transition duration-300 text-sm lg:text-base">Contacto</a>
             </div>
 
             <a href="https://api.whatsapp.com/send/?phone=5491138733447&text=Buenas%2C%20tengo%20inter%C3%A9s%20en%20tus%20servicios%20y%20me%20contacto%20por%20&type=phone_number&app_absent=0" target="_blank" rel="noopener noreferrer" title="Contactar por WhatsApp" class="p-2 focus:outline-none text-lg rounded-none" id="whatsapp-nav-icon">
@@ -62,12 +62,12 @@
     </div>
 
     <div id="mobile-menu" class="md:hidden hidden shadow-lg py-2 border-t">
-        <a href="../../index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
-        <a href="../../acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
-        <a href="../../clases.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Qígōng Tàijíquán</a>
-        <a href="../../asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
-        <a href="../../aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
-        <a href="../../index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
+        <a href="/index.html#bienvenida" class="block px-6 py-3 text-base transition duration-300 text-right">Inicio</a>
+        <a href="/acerca-de-mi.html" class="block px-6 py-3 text-base transition duration-300 text-right">Sobre Mí</a>
+        <a href="/clases/clases-presenciales.html" class="block px-6 py-3 text-base transition duration-300 text-right">Clases de Qígōng Tàijíquán</a>
+        <a href="/asistentes-ia.html" class="block px-6 py-3 text-base transition duration-300 text-right">Asistentes IA</a>
+        <a href="/aulavirtual.html" class="block px-6 py-3 text-base transition duration-300 text-right">Aula Virtual</a>
+        <a href="/index.html#contacto" class="block px-6 py-3 text-base transition duration-300 text-right">Contacto</a>
     </div>
 </nav>
     


### PR DESCRIPTION
## Summary
- Use root-relative links in navigation menus for class and topic pages
- Correct misdirected links in Qìgōng and Tàijí sections
- Standardize "Clases" link targets across subpages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d9ccad48320a00f2a9f3612ef88