### PR TITLE
Fix URL references on Taijiquan class page

### DIFF
--- a/clases/taiji.html
+++ b/clases/taiji.html
@@ -10,23 +10,23 @@
     <!-- Fuentes y estilos compartidos -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="/style.css">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css" />
     <link rel="preload" href="/background/003.webp" as="image">
-    <link rel="canonical" href="https://rodrigopizarro.com.ar/taiji.html">
+    <link rel="canonical" href="https://rodrigopizarro.com.ar/clases/taiji.html">
     <meta property="og:title" content="Tàijí - Rodrigo Pizarro">
     <meta property="og:description" content="Clases presenciales de Tàijíquán impartidas por Rodrigo Pizarro en Buenos Aires.">
     <meta property="og:image" content="https://rodrigopizarro.com.ar/img-mias/001.jpg">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://rodrigopizarro.com.ar/taiji.html">
+    <meta property="og:url" content="https://rodrigopizarro.com.ar/clases/taiji.html">
     <meta name="twitter:card" content="summary_large_image">
     <script type="application/ld+json">{
       "@context": "https://schema.org",
       "@type": "Person",
       "name": "Rodrigo Pizarro",
       "description": "Instructor de Qígōng Taiji y realizador multimedial",
-      "url": "https://rodrigopizarro.com.ar/taiji.html"
+      "url": "https://rodrigopizarro.com.ar/clases/taiji.html"
     }</script>
 </head>
 
@@ -58,9 +58,9 @@
               <li class="nav-item-has-children">
                 <a>Qìgōng</a>
                 <ul class="nav-submenu">
-                  <li><a href="qigong.html">Qué es el Qìgōng</a></li>
-                  <li><a href="qigong/wudangqigong.html">Wudang Qìgōng</a></li>
-                  <li><a href="qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
+                  <li><a href="/clases/qigong.html">Qué es el Qìgōng</a></li>
+                  <li><a href="/clases/qigong/wudangqigong.html">Wudang Qìgōng</a></li>
+                  <li><a href="/clases/qigong/mawangduidaoyinshu.html">Mawangdui Daoyin Shu</a></li>
                 </ul>
               </li>
       
@@ -68,7 +68,7 @@
               <li class="nav-item-has-children">
                 <a>Tàijí</a>
                 <ul class="nav-submenu">
-                  <li><a href="taiji.html">Qué es el Tàijí</a></li>
+                  <li><a href="/clases/taiji.html">Qué es el Tàijí</a></li>
                   <li><a href="/clases/taiji/taijiquan-oficial-updated.html">Tàijíquán</a></li>
 
                 </ul>
@@ -111,16 +111,16 @@
     
       <!-- Menú Mobile -->
       <div id="mobile-menu" class="hidden absolute right-0 mt-2 w-64 md:hidden shadow-lg rounded-lg bg-white text-right">
-        <a href="../../index.html#bienvenida" class="block px-4 py-2">Inicio</a>
-        <a href="../../acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
+        <a href="/index.html#bienvenida" class="block px-4 py-2">Inicio</a>
+        <a href="/acerca-de-mi.html" class="block px-4 py-2">Sobre Mí</a>
     
         <!-- Clases -->
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Clases</button>
           <div class="mobile-acc-panel">
-            <a href="../clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
-            <a href="../clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
-            <a href="../clases-particulares.html" class="block px-4 py-2">Particulares</a>
+            <a href="/clases/clases-presenciales.html" class="block px-4 py-2">Presenciales</a>
+            <a href="/clases/clases-virtuales.html" class="block px-4 py-2">Virtuales</a>
+            <a href="/clases/clases-particulares.html" class="block px-4 py-2">Particulares</a>
           </div>
         </div>
     
@@ -128,9 +128,9 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Qìgōng</button>
           <div class="mobile-acc-panel">
-            <a href="../qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
-            <a href="../wudang-qigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
-            <a href="mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
+            <a href="/clases/qigong.html" class="block px-4 py-2">Qué es el Qìgōng</a>
+            <a href="/clases/qigong/wudangqigong.html" class="block px-4 py-2">Wudang Qìgōng</a>
+            <a href="/clases/qigong/mawangduidaoyinshu.html" class="block px-4 py-2">Mawangdui Daoyin Shu</a>
           </div>
         </div>
     
@@ -138,7 +138,7 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Tàijí</button>
           <div class="mobile-acc-panel">
-            <a href="../taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
+            <a href="/clases/taiji.html" class="block px-4 py-2">Qué es el Tàijí</a>
             <a href="/clases/taiji.html#taijiquan-sistemas" class="block px-4 py-2">Tàijíquán</a>
           </div>
         </div>
@@ -147,13 +147,13 @@
         <div class="mobile-accordion">
           <button class="mobile-acc-btn block px-4 py-2 w-full">Servicios</button>
           <div class="mobile-acc-panel">
-            <a href="../asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
-            <a href="../aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
+            <a href="/asistentes-ia.html" class="block px-4 py-2">Asistentes IA</a>
+            <a href="/aulavirtual.html" class="block px-4 py-2">Aula Virtual</a>
           </div>
         </div>
     
         <!-- Contacto -->
-        <a href="../../index.html#contacto" class="block px-4 py-2">Contacto</a>
+        <a href="/index.html#contacto" class="block px-4 py-2">Contacto</a>
       </div>
     </div>    
 </nav>
@@ -234,14 +234,14 @@
         <section id="galeria_taiji" class="mb-16 md:mb-20 fade-in">
             <div class="container mx-auto px-6">
                 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-8 gap-8">
-                    <a href="img-mias/chuan (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (1).webp" alt="Chuan 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (2).webp" alt="Chuan 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (3).webp" alt="Chuan 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (5).webp" alt="Chuan 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (6).webp" alt="Chuan 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (7).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (7).webp" alt="Chuan 7" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (8).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (8).webp" alt="Chuan 8" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/chuan (9).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/chuan (9).webp" alt="Chuan 9" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (1).webp" alt="Chuan 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (2).webp" alt="Chuan 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (3).webp" alt="Chuan 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (5).webp" alt="Chuan 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (6).webp" alt="Chuan 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (7).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (7).webp" alt="Chuan 7" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (8).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (8).webp" alt="Chuan 8" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/chuan (9).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/chuan (9).webp" alt="Chuan 9" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
                 </div>
             </div>
         </section>
@@ -277,14 +277,14 @@
         <section id="galeria_taijijian" class="mb-16 md:mb-20 fade-in">
             <div class="container mx-auto px-6">
                 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-8 gap-8">
-                    <a href="img-mias/esp (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/esp (1).webp" alt="Detalle 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (1).webp" alt="Espada 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (2).webp" alt="Espada 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (3).webp" alt="Espada 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (4).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (4).webp" alt="Espada 4" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (5).webp" alt="Espada 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/espada (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/espada (6).webp" alt="Espada 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/esp (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/esp (2).webp" alt="Detalle 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/esp (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/esp (1).webp" alt="Detalle 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (1).webp" alt="Espada 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (2).webp" alt="Espada 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (3).webp" alt="Espada 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (4).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (4).webp" alt="Espada 4" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (5).webp" alt="Espada 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/espada (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/espada (6).webp" alt="Espada 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/esp (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/esp (2).webp" alt="Detalle 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
                 </div>
             </div>
         </section>
@@ -319,14 +319,14 @@
         <section id="galeria_taijishan" class="mb-16 md:mb-20 fade-in">
             <div class="container mx-auto px-6">
                 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-8 gap-8">
-                    <a href="img-mias/aba (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (1).webp" alt="Abanico 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (2).webp" alt="Abanico 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (3).webp" alt="Abanico 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (4).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (4).webp" alt="Abanico 4" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (5).webp" alt="Abanico 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (6).webp" alt="Abanico 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (7).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (7).webp" alt="Abanico 7" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
-                    <a href="img-mias/aba (8).webp" class="glightbox" data-gallery="mi-galeria"><img src="img-mias/aba (8).webp" alt="Abanico 8" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (1).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (1).webp" alt="Abanico 1" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (2).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (2).webp" alt="Abanico 2" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (3).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (3).webp" alt="Abanico 3" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (4).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (4).webp" alt="Abanico 4" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (5).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (5).webp" alt="Abanico 5" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (6).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (6).webp" alt="Abanico 6" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (7).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (7).webp" alt="Abanico 7" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
+                    <a href="/img-mias/aba (8).webp" class="glightbox" data-gallery="mi-galeria"><img src="/img-mias/aba (8).webp" alt="Abanico 8" class="rounded-none shadow-lg object-cover w-full h-48 md:h-full hover:opacity-80 transition-opacity duration-300" loading="lazy" decoding="async"></a>
                 </div>
             </div>
         </section>
@@ -360,12 +360,12 @@
 
     <!-- Carga de scripts compartidos -->
     <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js" defer></script>
-    <script src="js/hero-preload.js" defer></script>
-    <script src="js/global.js" defer></script>
-    <script src="js/navigation.js" defer></script>
-    <script src="js/theme-toggle.js" defer></script>
-    <script src="js/animations.js" defer></script>
-    <script src="js/glightbox-init.js" defer></script>
+    <script src="/js/hero-preload.js" defer></script>
+    <script src="/js/global.js" defer></script>
+    <script src="/js/navigation.js" defer></script>
+    <script src="/js/theme-toggle.js" defer></script>
+    <script src="/js/animations.js" defer></script>
+    <script src="/js/glightbox-init.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- fix canonical and metadata URLs to point at `/clases/taiji.html`
- convert navigation and mobile menu links to absolute paths
- correct image gallery and script references to root paths

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fdf00dc8320af599ea2805946ce